### PR TITLE
!!! DO NOT MERGE !!! Issue report.

### DIFF
--- a/internal/styxfile/dir.go
+++ b/internal/styxfile/dir.go
@@ -58,9 +58,9 @@ func (d *dirReader) ReadAt(p []byte, offset int64) (int, error) {
 	// by buffering Readdir's results.
 	nstats := len(p) / styxproto.MaxStatLen
 
-	if nstats == 0 {
+	/*if nstats == 0 {
 		return 0, ErrSmallRead
-	}
+	}*/
 
 	files, err := d.Readdir(nstats)
 	n, marshalErr := marshalStats(p, files, d.path, d.pool)


### PR DESCRIPTION
When attempting to send 9p messages larger than the 9p message size agreed upon by the client and server, some clients - e.g., the Linux 9p driver - will perform 'partial reads' of messages, breaking things up into small enough pieces to work. This means that while a message may end up being larger than the agreed-upon size, those messages can still successfully be transferred.

In this patch, I removed the line of code that was artificially preventing those connections from working - a change I had made in order to get a personal project up and running. This meant that the code went from messages that were too large not being sent, to messages that were too large successfully transferring. My client was the standard linux 9p module.

Unfortunately, I was awful and didn't save the code that was running into the issue for a reproducible - but I thought this PR might still help track down how you'd like to approach the problem.

Thanks!

Marzhall