### PR TITLE
correct error message so that the type failing conversion is correctly reported.

### DIFF
--- a/internal/styxfile/file.go
+++ b/internal/styxfile/file.go
@@ -65,8 +65,9 @@ func New(rwc interface{}) (Interface, error) {
 		return &dumbPipe{rwc: rwc}, nil
 	case io.Writer:
 		return &dumbPipe{rwc: rwc}, nil
+	default:
+		return nil, fmt.Errorf("Cannot convert type %T into a styxfile.Interface", rwc)
 	}
-	return nil, fmt.Errorf("Cannot convert type %T into a styxfile.Interface")
 }
 
 // SetDeadline sets read/write deadlines for a file, if the type supports it.

--- a/request.go
+++ b/request.go
@@ -156,7 +156,7 @@ func (t Topen) Ropen(rwc interface{}, err error) {
 	}
 
 	if err != nil {
-		t.session.conn.srv.logf("%s open %s failed: %s", t.path, err)
+		t.session.conn.srv.logf("open %s failed: %s", t.path, err)
 
 		// Don't want to expose too many implementation details
 		// to clients.


### PR DESCRIPTION
Before this change, the error reported for types failing conversion would always be:

    / open Cannot convert type %!T(MISSING) into a styxfile.Interface failed: %!s(MISSING)

regardless of the type failing conversion. This was because the type value `rwc` was not being passed to the fmt function.

I've updated the code to move the default case into the switch scope, where I then added the argument for type being switched upon. This correctly reports the type being used.