### PR TITLE
Fix format of some Errorf and Fatalf calls

### DIFF
--- a/internal/styxfile/file.go
+++ b/internal/styxfile/file.go
@@ -66,7 +66,7 @@ func New(rwc interface{}) (Interface, error) {
 	case io.Writer:
 		return &dumbPipe{rwc: rwc}, nil
 	}
-	return nil, fmt.Errorf("Cannot convert type %T into a styxfile.Interface")
+	return nil, fmt.Errorf("Cannot convert type %T into a styxfile.Interface", rwc)
 }
 
 // SetDeadline sets read/write deadlines for a file, if the type supports it.

--- a/internal/threadsafe/map_test.go
+++ b/internal/threadsafe/map_test.go
@@ -40,6 +40,6 @@ func TestMap(t *testing.T) {
 	if !m.Fetch("foo", &x) {
 		t.Error("m.Fetch did not find \"foo\" in map")
 	} else if x != 83 {
-		t.Error("m.Update did not update value for \"foo\" (%v)", x)
+		t.Errorf("m.Update did not update value for \"foo\" (%v)", x)
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -454,6 +454,6 @@ func TestWalk(t *testing.T) {
 	})
 
 	if count != len(elem) {
-		t.Errorf("Twalk(%q) generated %d, requests, wanted %d", count, len(elem))
+		t.Errorf("Twalk(%q) generated %d, requests, wanted %d", walkPath, count, len(elem))
 	}
 }

--- a/styxproto/encoding_test.go
+++ b/styxproto/encoding_test.go
@@ -28,7 +28,7 @@ func TestEncode(t *testing.T) {
 			t.Logf("%T %s", msg, msg)
 		}
 		if dec.Err() != nil {
-			t.Fatal("× %s", dec.Err())
+			t.Fatalf("× %s", dec.Err())
 		}
 	}
 


### PR DESCRIPTION
Go1.11 doesn't compile a code with format issues anymore.