### PR TITLE
Add factotum RPC support for plan9

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -268,7 +268,7 @@ func (c *conn) acceptTversion() bool {
 // - close connections that have not established a session in N seconds
 func (c *conn) handleTauth(ctx context.Context, m styxproto.Tauth) bool {
 	var (
-		f interface{}
+		f   interface{}
 		err error
 	)
 	defer c.Flush()
@@ -331,7 +331,7 @@ func (c *conn) handleTattach(ctx context.Context, m styxproto.Tattach) bool {
 		s = newSession(c, m)
 	} else {
 		var (
-			ok bool
+			ok  bool
 			err error
 		)
 		s, ok = c.sessionByFid(m.Afid())

--- a/conn.go
+++ b/conn.go
@@ -149,7 +149,7 @@ func newConn(srv *Server, rwc io.ReadWriteCloser) *conn {
 		Encoder:    enc,
 		srv:        srv,
 		rwc:        rwc,
-		ctx:        context.TODO(),
+		ctx:        context.Background(),
 		msize:      msize,
 		sessionFid: threadsafe.NewMap(),
 		pendingReq: threadsafe.NewMap(),
@@ -267,6 +267,10 @@ func (c *conn) acceptTversion() bool {
 // - Setting a per-connection session limit
 // - close connections that have not established a session in N seconds
 func (c *conn) handleTauth(ctx context.Context, m styxproto.Tauth) bool {
+	var (
+		f interface{}
+		err error
+	)
 	defer c.Flush()
 	if c.srv.Auth == nil {
 		c.clearTag(m.Tag())
@@ -278,25 +282,38 @@ func (c *conn) handleTauth(ctx context.Context, m styxproto.Tauth) bool {
 		c.Rerror(m.Tag(), "fid %x in use", m.Afid())
 		return true
 	}
-	client, server := net.Pipe()
-	ch := &Channel{
-		Context:         c.ctx,
-		ReadWriteCloser: server,
+	s := newSession(c, m)
+
+	if c.srv.OpenAuth == nil {
+		var server net.Conn
+		f, server = net.Pipe()
+		ch := &Channel{
+			Context:         c.ctx,
+			ReadWriteCloser: server,
+		}
+		go func() {
+			s.authC <- c.srv.Auth(ch, s.User, s.Access)
+			close(s.authC)
+		}()
+	} else {
+		f, err = c.srv.OpenAuth()
+		if err != nil {
+			c.clearTag(m.Tag())
+			c.Rerror(m.Tag(), "styx.Server.OpenAuth: %s", err.Error())
+			return true
+		}
+		c.ctx = context.WithValue(c.ctx, "Auth", f)
 	}
-	rwc, err := styxfile.New(client)
+	rwc, err := styxfile.New(f)
 	if err != nil {
 		// This should never happen
 		panic(err)
 	}
-	s := newSession(c, m)
-	go func() {
-		s.authC <- c.srv.Auth(ch, s.User, s.Access)
-		close(s.authC)
-	}()
-
-	c.sessionFid.Put(m.Afid(), s)
 	s.files.Put(m.Afid(), file{rwc: rwc, auth: true})
+	c.sessionFid.Put(m.Afid(), s)
 	s.IncRef()
+	c.clearTag(m.Tag())
+	c.Rauth(m.Tag(), c.qid("auth", styxproto.QTAUTH))
 	return true
 }
 
@@ -313,13 +330,15 @@ func (c *conn) handleTattach(ctx context.Context, m styxproto.Tattach) bool {
 	if c.srv.Auth == nil {
 		s = newSession(c, m)
 	} else {
-		// TODO(droyo) when a transport-based authentication scheme
-		// is in use, the client should not have to do a Tauth request.
-		// We should call the Auth handler if Afid is NOFID, passing it
-		// a util.BlackHole.
-		if !c.sessionFid.Fetch(s, m.Afid()) {
+		var (
+			ok bool
+			err error
+		)
+		s, ok = c.sessionByFid(m.Afid())
+		if !ok {
 			c.clearTag(m.Tag())
-			c.Rerror(m.Tag(), "invalid afid %x", m.Afid())
+			c.Rerror(m.Tag(), "%s", errNoFid)
+			c.Flush()
 			return true
 		}
 		// From attach(5): The same validated afid may be used for
@@ -329,7 +348,12 @@ func (c *conn) handleTattach(ctx context.Context, m styxproto.Tattach) bool {
 			c.Rerror(m.Tag(), "afid mismatch for %s on %s", m.Uname(), m.Aname())
 			return true
 		}
-		if err := <-s.authC; err != nil {
+		if c.srv.OpenAuth == nil {
+			err = <-s.authC
+		} else {
+			err = c.srv.Auth(&Channel{c.ctx, nil}, s.User, s.Access)
+		}
+		if err != nil {
 			c.clearTag(m.Tag())
 			c.Rerror(m.Tag(), "auth failed: %s", err)
 			return true

--- a/server.go
+++ b/server.go
@@ -16,6 +16,8 @@ type Logger interface {
 	Printf(string, ...interface{})
 }
 
+type AuthOpenFunc func() (interface{}, error)
+
 // A Server defines parameters for running a 9P server. The
 // zero value of a Server is usable as a 9P server, and will
 // use the defaults set by the styx package.
@@ -41,6 +43,9 @@ type Server struct {
 	// Auth is used to authenticate user sessions. If nil,
 	// authentication is disabled.
 	Auth AuthFunc
+
+	// OpenAuth is used to open file to authentication agent
+	OpenAuth AuthOpenFunc
 
 	// If not nil, ErrorLog will be used to log unexpected
 	// errors accepting or handling connections. TraceLog,

--- a/styxauth/factotum/factotum_plan9.go
+++ b/styxauth/factotum/factotum_plan9.go
@@ -1,0 +1,168 @@
+package factotum
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"bytes"
+	"log"
+
+	"aqwari.net/net/styx"
+)
+
+const (
+	//Factotum rpc responses
+	ARok = "ok"
+	ARdone = "done"
+	ARerror = "error"
+	ARbadkey = "badkey"
+	ARtoosmall = "toosmall"
+	ARphase = "phase"
+	ARneedkey = "needkey"
+
+	//Factotum rpc commands
+	ARread = "read"
+	ARwrite = "write"
+	ARauthinfo = "authinfo"
+	ARstart = "start"
+
+	AuthRpcMax = 4096
+)
+
+var tab = []string{ARok, ARdone, ARerror, ARneedkey, ARbadkey, ARtoosmall, ARphase}
+
+var ErrMalformedRpc = errors.New("malformed rpc response")
+
+var ErrUnknownRpc = errors.New("Unknown rpc")
+
+var ErrBotchRpc = errors.New("authrpc botch")
+
+type AuthRpc struct {
+	*os.File
+}
+
+//See /sys/src/libauth/auth_rpc.c:/^classify/
+func (a *AuthRpc) classify(b []byte) (string, []byte, error) {
+	for _, s := range tab {
+		if bytes.HasPrefix(b, []byte(s)) {
+			if len(b) == len(s) {
+				return s, b, nil
+			}
+			return s, b[len(s)+1:], nil
+		}
+	}
+	return "", nil, ErrMalformedRpc
+}
+
+//See /sys/src/libauth/auth_rpc.c:/^auth_rpc/
+func (a *AuthRpc) do(verb string, b []byte) (string, []byte, error) {
+	b = append(append([]byte(verb), byte(' ')), b...)
+	a.Write(b)
+
+	b = make([]byte, AuthRpcMax)
+	_, err := a.Read(b)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var ret string
+	ret, b, err = a.classify(b)
+	if err != nil {
+		return ret, b, err
+	}
+	log.Println("Got phase", ret)
+	switch ret {
+	default:
+		return ret, nil, ErrUnknownRpc
+	case ARdone:
+	case ARok:
+	case ARneedkey:
+		fallthrough
+	case ARbadkey:
+		fallthrough
+	case ARphase:
+		fallthrough
+	case ARerror:
+		return ret, nil, errors.New(string(b))
+	}
+	return ret, b, nil
+}
+
+//See /sys/src/lib9p/auth.c:/^_authread/
+func (a *AuthRpc) ReadAt(b []byte, off int64) (int, error) {
+	ret, resp, err := a.do(ARread, b)
+	if err != nil {
+		return 0, err 
+	}
+	switch ret {
+	default:
+		return 0, ErrBotchRpc
+	case ARdone:
+		fallthrough
+	case ARok:
+		copy(b, resp)
+		return len(b), nil
+	}
+	return 0, ErrBotchRpc
+}
+
+//See /sys/src/lib9p/auth.c:/^authwrite/
+func (a *AuthRpc) WriteAt(b []byte, off int64) (int, error) {
+	ret, _, err := a.do(ARwrite, b)
+	if err != nil {
+		return 0, err
+	}
+	switch ret {
+	default:
+		return 0, ErrBotchRpc
+	case ARdone:
+		fallthrough
+	case ARok:
+		return len(b), nil
+	}
+	return 0, ErrBotchRpc
+}
+
+func (a *AuthRpc) Close() error {
+	return nil
+}
+
+func Start(proto string) (styx.AuthFunc, styx.AuthOpenFunc) {
+	s := fmt.Sprintf("proto=%s role=server", proto)
+
+	af := func(rwc *styx.Channel, user, access string) error {
+		i := rwc.Context.Value("Auth")
+		if i == nil {
+			return errors.New("Tattach before Tauth")
+		}
+		a, ok := i.(*AuthRpc)
+		if !ok {
+			return errors.New("cast to AuthRpc failed")
+		}
+		ret, _, err := a.do("read", []byte{})
+		if err != nil {
+			return err
+		}
+		if ret != ARdone {
+			return errors.New("Auth is not done")
+		}
+		return nil
+	}
+	aof := func() (interface{}, error) {
+		f, err := os.OpenFile("/mnt/factotum/rpc", os.O_RDWR, 0755)
+		if err != nil {
+			return nil, nil
+		}
+		a := &AuthRpc{f}
+
+		ret, _, err := a.do("start", []byte(s))
+		if err != nil {
+			return nil, err
+		}
+		if ret != ARok {
+			return nil, errors.New("did not get OK for start")
+		}
+		return a, nil
+	}
+	return af, aof
+}

--- a/styxauth/factotum/factotum_plan9.go
+++ b/styxauth/factotum/factotum_plan9.go
@@ -1,30 +1,30 @@
 package factotum
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"os"
-	"bytes"
 	"log"
+	"os"
 
 	"aqwari.net/net/styx"
 )
 
 const (
 	//Factotum rpc responses
-	ARok = "ok"
-	ARdone = "done"
-	ARerror = "error"
-	ARbadkey = "badkey"
+	ARok       = "ok"
+	ARdone     = "done"
+	ARerror    = "error"
+	ARbadkey   = "badkey"
 	ARtoosmall = "toosmall"
-	ARphase = "phase"
-	ARneedkey = "needkey"
+	ARphase    = "phase"
+	ARneedkey  = "needkey"
 
 	//Factotum rpc commands
-	ARread = "read"
-	ARwrite = "write"
+	ARread     = "read"
+	ARwrite    = "write"
 	ARauthinfo = "authinfo"
-	ARstart = "start"
+	ARstart    = "start"
 
 	AuthRpcMax = 4096
 )
@@ -92,7 +92,7 @@ func (a *AuthRpc) do(verb string, b []byte) (string, []byte, error) {
 func (a *AuthRpc) ReadAt(b []byte, off int64) (int, error) {
 	ret, resp, err := a.do(ARread, b)
 	if err != nil {
-		return 0, err 
+		return 0, err
 	}
 	switch ret {
 	default:
@@ -139,7 +139,7 @@ func Start(proto string) (styx.AuthFunc, styx.AuthOpenFunc) {
 		if !ok {
 			return errors.New("cast to AuthRpc failed")
 		}
-		ret, _, err := a.do("read", []byte{})
+		ret, _, err := a.do(ARread, []byte{})
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func Start(proto string) (styx.AuthFunc, styx.AuthOpenFunc) {
 		}
 		a := &AuthRpc{f}
 
-		ret, _, err := a.do("start", []byte(s))
+		ret, _, err := a.do(ARstart, []byte(s))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds support for the use of the factotum RPC for authentication. This allows for clients to authenticate through the use of dp9ik or 9psk1 to the server, if the server is running on plan9.

This required another Auth function be added to the styx.Server struct for opening an auth file in the same style of the Ropen function used by handlers. This was necessary to keep information regarding incoming Tread and Twrite sizes that are otherwise lost when using a styxfile.dumpPipe. 