### PR TITLE
Fix for GOARCH=arm 

### DIFF
--- a/internal/qidpool/pool.go
+++ b/internal/qidpool/pool.go
@@ -13,8 +13,8 @@ import (
 // for files on a 9P file server. A Pool must be created
 // with a call to New.
 type Pool struct {
-	m    *threadsafe.Map
 	path uint64
+	m    *threadsafe.Map
 }
 
 // New returns a new, empty Pool.

--- a/session.go
+++ b/session.go
@@ -22,6 +22,11 @@ import (
 // a user may perform multiple operations on multiple files. Multiple
 // sessions may be multiplexed over a single connection.
 type Session struct {
+	// This tracks the number of fids pointing to this session in
+	// conn.sessionFid. We need to know when all references are gone
+	// so we can properly close any session channels.
+	util.RefCount
+
 	// User is the name of the user associated with the session.
 	// When establishing a session, the client provides a username, This
 	// may or may not be authenticated, depending on the Server in use.
@@ -62,11 +67,6 @@ type Session struct {
 
 	// Underlying connection this session takes place on.
 	*conn
-
-	// This tracks the number of fids pointing to this session in
-	// conn.sessionFid. We need to know when all references are gone
-	// so we can properly close any session channels.
-	util.RefCount
 
 	// Open (or unopened) files, indexed by fid.
 	files *threadsafe.Map

--- a/styxproto/decoder.go
+++ b/styxproto/decoder.go
@@ -149,11 +149,11 @@ func (s *Decoder) resetdot() {
 	s.start, s.pos = 0, 0
 }
 
-func (s *Decoder) advance(n int) {
-	if s.buflen() < n {
+func (s *Decoder) advance(n uint32) {
+	if uint32(s.buflen()) < n {
 		panic("advance decoder out of bounds")
 	}
-	s.pos += n
+	s.pos = int(uint32(s.pos) +  n)
 }
 
 func (s *Decoder) shrinkdot(n int) {
@@ -179,20 +179,20 @@ func (s *Decoder) dotlen() int {
 
 // extends dot to be n bytes long, performing
 // IO if necessary. returns dot
-func (s *Decoder) growdot(n int) ([]byte, error) {
-	if err := s.fill(n - s.dotlen()); err != nil {
+func (s *Decoder) growdot(n uint32) ([]byte, error) {
+	if err := s.fill(n - uint32(s.dotlen())); err != nil {
 		return nil, err
 	}
-	s.advance(n - s.dotlen())
+	s.advance(n - uint32(s.dotlen()))
 	return s.dot(), nil
 }
 
 // guarantees that s.buflen() >= n if error is nil
-func (s *Decoder) fill(n int) error {
-	if maxInt-n < s.pos {
+func (s *Decoder) fill(n uint32) error {
+	if uint32(maxInt)-n < uint32(s.pos) {
 		return errFillOverflow
 	}
-	_, err := s.br.Peek(s.pos + n)
+	_, err := s.br.Peek(int(uint32(s.pos) + n))
 	return err
 }
 

--- a/styxproto/encoder.go
+++ b/styxproto/encoder.go
@@ -48,7 +48,7 @@ func (enc *Encoder) Tversion(msize uint32, version string) {
 	if len(version) > MaxVersionLen {
 		version = version[:MaxVersionLen]
 	}
-	size := uint32(minSizeLUT[msgTversion] + len(version))
+	size := minSizeLUT[msgTversion] + uint32(len(version))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -63,7 +63,7 @@ func (enc *Encoder) Rversion(msize uint32, version string) {
 	if len(version) > MaxVersionLen {
 		version = version[:MaxVersionLen]
 	}
-	size := uint32(minSizeLUT[msgRversion] + len(version))
+	size := minSizeLUT[msgRversion] + uint32(len(version))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -82,7 +82,7 @@ func (enc *Encoder) Tauth(tag uint16, afid uint32, uname, aname string) {
 	if len(aname) > MaxAttachLen {
 		aname = aname[:MaxAttachLen]
 	}
-	size := uint32(minSizeLUT[msgTauth] + len(uname) + len(aname))
+	size := minSizeLUT[msgTauth] + uint32(len(uname)) + uint32(len(aname))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -113,7 +113,7 @@ func (enc *Encoder) Tattach(tag uint16, fid, afid uint32, uname, aname string) {
 	if len(aname) > MaxAttachLen {
 		aname = aname[:MaxAttachLen]
 	}
-	size := uint32(minSizeLUT[msgTattach] + len(uname) + len(aname))
+	size := minSizeLUT[msgTattach] + uint32(len(uname)) + uint32(len(aname))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -145,7 +145,7 @@ func (enc *Encoder) Rerror(tag uint16, errfmt string, v ...interface{}) {
 	if len(ename) > MaxErrorLen {
 		ename = ename[:MaxErrorLen]
 	}
-	size := uint32(minSizeLUT[msgRerror] + len(ename))
+	size := minSizeLUT[msgRerror] + uint32(len(ename))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -208,7 +208,7 @@ func (enc *Encoder) Rwalk(tag uint16, wqid ...Qid) error {
 	if len(wqid) > MaxWElem {
 		return errMaxWElem
 	}
-	size := uint32(minSizeLUT[msgRwalk] + 13*len(wqid))
+	size := minSizeLUT[msgRwalk] + uint32(13*len(wqid))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -249,7 +249,7 @@ func (enc *Encoder) Tcreate(tag uint16, fid uint32, name string, perm uint32, mo
 	if len(name) > MaxFilenameLen {
 		name = name[:MaxFilenameLen]
 	}
-	size := uint32(minSizeLUT[msgTcreate] + len(name))
+	size := minSizeLUT[msgTcreate] + uint32(len(name))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -330,7 +330,7 @@ func (enc *Encoder) Rread(tag uint16, data []byte) (n int, err error) {
 // Twrite writes a Twrite message to the underlying io.Writer. An error is returned
 // if the message cannot fit inside a single 9P message.
 func (enc *Encoder) Twrite(tag uint16, fid uint32, offset int64, data []byte) (int, error) {
-	if math.MaxUint32-minSizeLUT[msgTwrite] < len(data) {
+	if math.MaxUint32-uint32(minSizeLUT[msgTwrite]) < uint32(len(data)) {
 		return 0, errTooBig
 	}
 	size := uint32(minSizeLUT[msgTwrite]) + uint32(len(data))
@@ -419,7 +419,7 @@ func (enc *Encoder) Rstat(tag uint16, stat Stat) {
 	if len(stat) < minStatLen {
 		panic(errShortStat)
 	}
-	size := uint32((minSizeLUT[msgRstat] - minStatLen) + len(stat))
+	size := minSizeLUT[msgRstat] - uint32(minStatLen) + uint32(len(stat))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()
@@ -438,7 +438,7 @@ func (enc *Encoder) Twstat(tag uint16, fid uint32, stat Stat) {
 	if len(stat) < minStatLen {
 		panic(errShortStat)
 	}
-	size := uint32(minSizeLUT[msgTwstat] + 2 + len(stat))
+	size := minSizeLUT[msgTwstat] + uint32(2 + len(stat))
 
 	enc.mu.Lock()
 	defer enc.mu.Unlock()

--- a/styxproto/limits.go
+++ b/styxproto/limits.go
@@ -7,7 +7,7 @@ const maxInt = int(^uint(0) >> 1)
 // things, we set some limits on how big any of these fields can be.
 
 // Minimum size of a message
-var minSizeLUT = [...]int{
+var minSizeLUT = [...]uint32{
 	msgTversion: 13,             // size[4] Tversion tag[2] msize[4] version[s]
 	msgRversion: 13,             // size[4] Rversion tag[2] mversion[s]
 	msgTauth:    15,             // size[4] Tauth tag[2] afid[4] uname[s] aname[s]
@@ -38,7 +38,7 @@ var minSizeLUT = [...]int{
 }
 
 // Maximum size of a message
-var maxSizeLUT = [...]int{
+var maxSizeLUT = [...]uint32{
 	msgTversion: minSizeLUT[msgTversion] + MaxVersionLen,
 	msgRversion: minSizeLUT[msgRversion] + MaxVersionLen,
 	msgTauth:    minSizeLUT[msgTauth] + MaxUidLen + MaxAttachLen,

--- a/styxproto/parse.go
+++ b/styxproto/parse.go
@@ -83,7 +83,7 @@ func (s *Decoder) readFixed() (Msg, error) {
 	msg := msg(s.dot())
 	msgSize, msgType := msg.Len(), msg.Type()
 
-	msg, err := s.growdot(int(msgSize))
+	msg, err := s.growdot(uint32(msgSize))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (s *Decoder) readRW() (Msg, error) {
 		readSize = int(msgSize)
 	}
 
-	msg, err = s.growdot(readSize)
+	msg, err = s.growdot(uint32(readSize))
 	if err != nil {
 		// we have already buffered IOHeaderSize bytes, so
 		// we are reading from the bufio.Reader's internal buffer.
@@ -152,7 +152,7 @@ func (s *Decoder) badMessage(bad msg, reason error) (Msg, error) {
 	// from hurting performance for others on the same connection.
 	if s.dotlen() > int(length) {
 		s.shrinkdot(s.dotlen() - int(length))
-	} else if _, err := s.growdot(int(length)); err != nil {
+	} else if _, err := s.growdot(uint32(length)); err != nil {
 		panic(err)
 	}
 	s.mark()


### PR DESCRIPTION
This fixes build for arm by specifying int width in a few places as well as reorganizing some struct members to work around this [bug](https://github.com/golang/go/issues/23345) with atomic on arm.