### PR TITLE
Revisit arm support

### DIFF
--- a/styxproto/decoder.go
+++ b/styxproto/decoder.go
@@ -189,7 +189,7 @@ func (s *Decoder) growdot(n uint32) ([]byte, error) {
 
 // guarantees that s.buflen() >= n if error is nil
 func (s *Decoder) fill(n uint32) error {
-	if uint32(maxInt)-n < uint32(s.pos) {
+	if uint32(maxInt32 - n) < uint32(s.pos) {
 		return errFillOverflow
 	}
 	_, err := s.br.Peek(int(uint32(s.pos) + n))

--- a/styxproto/limits.go
+++ b/styxproto/limits.go
@@ -1,6 +1,11 @@
 package styxproto
 
-const maxInt = int(^uint(0) >> 1)
+import (
+	"math"
+)
+
+const maxInt64 = math.MaxInt64
+const maxInt32 = math.MaxInt32
 
 // Validating messages becomes more complicated if we allow arbitrarily-long
 // values for some of the non-fixed fields in a message.  To simplify


### PR DESCRIPTION
I'm currently working on a file system using styx that can't be built for arm due to overflow errors: https://github.com/henesy/abfs/issues/1

Notably, the old constant code yields a value that indicates a 64-bit integer: https://play.golang.org/p/AUpYTNF6hhs

However, I don't believe a 64-bit integer is necessary here for 9p parsing, I could be incorrect and am open to further input :)

The changes provided seem to pass `go test` and builds with no warnings/errors for GOARCH=arm. 

I saw that the commit I based this off of was reverted due to tests failing, would it be possible to get details on what was failing if this patch doesn't solve the issues?

Hardware used was a Raspberry Pi 1 running 9front/arm. 

Tested against jsonfs - my fs is still a port in progress to plan9. 