### PR TITLE
Fix Rwalk() setting QIDs erroneously

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -161,6 +161,10 @@ func (c *conn) qid(name string, qtype uint8) styxproto.Qid {
 	return c.qidpool.Put(name, qtype)
 }
 
+func (c *conn) getQid(name string, qtype uint8) (styxproto.Qid, bool) {
+	return c.qidpool.Get(name)
+}
+
 // All request contexts must have their cancel functions
 // called, to free up resources in the context. Returns false
 // if the tag is already cancelled

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module aqwari.net/net/styx
+
+go 1.16
+
+require aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0 h1:BeD6U5TNwhMWxeydyi5xqpaNZx1MWl5QTcW4w7Mxf+Y=
+aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0/go.mod h1:XSNyyoM+OSg3vRmROPrS1lEpV7q/I9J1HAKMMxdUkU4=

--- a/internal/qidpool/pool.go
+++ b/internal/qidpool/pool.go
@@ -42,6 +42,7 @@ func (p *Pool) Put(name string, qtype uint8) styxproto.Qid {
 			m[name] = qid
 		}
 	})
+
 	p.m.Put(name, qid)
 	return qid
 }

--- a/request.go
+++ b/request.go
@@ -1,9 +1,9 @@
 package styx
 
 import (
+	"context"
 	"os"
 	"path"
-	"context"
 
 	"aqwari.net/net/styx/internal/styxfile"
 	"aqwari.net/net/styx/internal/sys"

--- a/request.go
+++ b/request.go
@@ -3,7 +3,6 @@ package styx
 import (
 	"os"
 	"path"
-
 	"context"
 
 	"aqwari.net/net/styx/internal/styxfile"
@@ -266,6 +265,7 @@ func (t Tcreate) Rcreate(rwc interface{}, err error) {
 	}
 
 	if dir, ok := rwc.(Directory); t.Mode.IsDir() && ok {
+
 		f = styxfile.NewDir(dir, path.Join(t.Path(), t.Name), t.session.conn.qidpool)
 	} else {
 		f, err = styxfile.New(rwc)

--- a/walk.go
+++ b/walk.go
@@ -1,11 +1,11 @@
 package styx
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
 	"strings"
-	"errors"
 
 	"context"
 

--- a/walk.go
+++ b/walk.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"errors"
 
 	"context"
 
@@ -180,7 +181,12 @@ func (t Twalk) Rwalk(info os.FileInfo, err error) {
 	var mode os.FileMode
 	if err == nil {
 		mode = info.Mode()
-		qid = t.session.conn.qid(t.Path(), styxfile.QidType(styxfile.Mode9P(mode)))
+		fqid, found := t.session.conn.getQid(t.Path(), styxfile.QidType(styxfile.Mode9P(mode)))
+		if !found {
+			err = errors.New("rwalk did not find file")
+		} else {
+			qid = fqid
+		}
 	}
 	t.walk.filled[t.index] = 1
 	elem := walkElem{qid: qid, index: t.index, err: err}


### PR DESCRIPTION
Commit message: `request.go: add getQid() to permit lookup of QIDs without accidentally setting non-existant QIDs. ;; make Rwalk() use getQid()`

Rwalk() originally called Put() in the Qid Pool to check if the Qid existed in the tree. 

In the case of a new file being created in the tree, a Twalk, then a Tcreate, would occur. 

Tcreate should be the only origin of 'new' QIDs to the core file system. 

The original Rwalk call would, for a file that doesn't exist yet, set a QID with a type of 128, being a directory. 

Thus, any new file created would be created with a Qtype of a directory, even if the file mode wasn't that of a directory. 

Weird behavior ensues where writes fail from the client side as 'file is a directory'. 

Additionally, the Put() function for the QID pool does not override existing entries with the provided value. This may be intended, but also meant that when the original value was erroneously set by Rwalk, that future correct calls, such as from Rcreate, would fail to set the Qtype correctly. 

This PR resolves the Rwalk() Qid creation issue by introducing a getQid() function which acts similar to a standard lookup on a Go map type. 