### PR TITLE
Avoid creating bad messages through the result of fallback `statGuess` name guesses, add test

### DIFF
--- a/internal/styxfile/file.go
+++ b/internal/styxfile/file.go
@@ -130,6 +130,8 @@ func Stat(buf []byte, file Interface, name string, qid styxproto.Qid) (styxproto
 	return stat, nil
 }
 
+// FIXME: When statGuess is used with a styxfile.Directory, none of the stat methods are found,
+// and we fall back on incorrectly using guessed values every time.
 type statGuess struct {
 	file  Interface
 	name  string

--- a/internal/styxfile/file.go
+++ b/internal/styxfile/file.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"aqwari.net/net/styx/internal/sys"
@@ -110,6 +111,10 @@ func Stat(buf []byte, file Interface, name string, qid styxproto.Qid) (styxproto
 			return nil, err
 		}
 	} else {
+		// name is an absolute path, make sure we don't pass an absolute path to statGuess,
+		// otherwise we may get back an absolute path if the file does not have a Name() method,
+		// which would be incorrect since stat names cannot contain slashes.
+		name := filepath.Base(name)
 		fi = statGuess{file, name, qid.Type()}
 	}
 	uid, gid, muid := sys.FileOwner(fi)


### PR DESCRIPTION
- We make sure the fallback statGuess name is the base file name, not the absolute path.
Otherwise in scenarios where statGuess does not manage to find a Name method on the underlying object,
it will return an absolute path, which will generate bad message errors,
due to slashes not being allowed in file names.
- Introduce an additional test for Tcreate, which prevents this behaviour from happening in the future, and also detects a different problem (currently unfixed):
When a styxfile.Directory is passed as the result of a Tcreate call
and the underlying object does not have a Stat method,
statGuess does not manage to detect any underlying fs.FileInfo methods,
(e.g.: Name, Mode, ...) which means that for opened directories,
the results of Tstat are always an incorrectly guessed fallback value

Resolves #35 