### PR TITLE
Revert incorrect Rwalk changes, introduce additional test

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -161,10 +161,6 @@ func (c *conn) qid(name string, qtype uint8) styxproto.Qid {
 	return c.qidpool.Put(name, qtype)
 }
 
-func (c *conn) getQid(name string, qtype uint8) (styxproto.Qid, bool) {
-	return c.qidpool.Get(name)
-}
-
 // All request contexts must have their cancel functions
 // called, to free up resources in the context. Returns false
 // if the tag is already cancelled

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,0 @@
-module aqwari.net/net/styx
-
-go 1.16
-
-require aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module aqwari.net/net/styx
+
+go 1.19
+
+require aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0 h1:BeD6U5TNwhMWxeydyi5xqpaNZx1MWl5QTcW4w7Mxf+Y=
+aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0/go.mod h1:XSNyyoM+OSg3vRmROPrS1lEpV7q/I9J1HAKMMxdUkU4=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0 h1:BeD6U5TNwhMWxeydyi5xqpaNZx1MWl5QTcW4w7Mxf+Y=
-aqwari.net/retry v0.0.0-20180428204214-1281ce5d8df0/go.mod h1:XSNyyoM+OSg3vRmROPrS1lEpV7q/I9J1HAKMMxdUkU4=

--- a/internal/qidpool/pool.go
+++ b/internal/qidpool/pool.go
@@ -42,7 +42,6 @@ func (p *Pool) Put(name string, qtype uint8) styxproto.Qid {
 			m[name] = qid
 		}
 	})
-	p.m.Put(name, qid)
 	return qid
 }
 

--- a/internal/qidpool/pool.go
+++ b/internal/qidpool/pool.go
@@ -42,7 +42,6 @@ func (p *Pool) Put(name string, qtype uint8) styxproto.Qid {
 			m[name] = qid
 		}
 	})
-
 	p.m.Put(name, qid)
 	return qid
 }

--- a/request.go
+++ b/request.go
@@ -1,9 +1,10 @@
 package styx
 
 import (
-	"context"
 	"os"
 	"path"
+
+	"context"
 
 	"aqwari.net/net/styx/internal/styxfile"
 	"aqwari.net/net/styx/internal/sys"
@@ -265,7 +266,6 @@ func (t Tcreate) Rcreate(rwc interface{}, err error) {
 	}
 
 	if dir, ok := rwc.(Directory); t.Mode.IsDir() && ok {
-
 		f = styxfile.NewDir(dir, path.Join(t.Path(), t.Name), t.session.conn.qidpool)
 	} else {
 		f, err = styxfile.New(rwc)

--- a/walk.go
+++ b/walk.go
@@ -1,7 +1,6 @@
 package styx
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -181,12 +180,7 @@ func (t Twalk) Rwalk(info os.FileInfo, err error) {
 	var mode os.FileMode
 	if err == nil {
 		mode = info.Mode()
-		fqid, found := t.session.conn.getQid(t.Path(), styxfile.QidType(styxfile.Mode9P(mode)))
-		if !found {
-			err = errors.New("rwalk did not find file")
-		} else {
-			qid = fqid
-		}
+		qid = t.session.conn.qid(t.Path(), styxfile.QidType(styxfile.Mode9P(mode)))
 	}
 	t.walk.filled[t.index] = 1
 	elem := walkElem{qid: qid, index: t.index, err: err}


### PR DESCRIPTION
Reverts incorrect changes introduced in https://github.com/droyo/styx/pull/30, which broke Rwalk (for which there were failing tests that went unnoticed).

Also removes a superfluous Put call in qidpool: if it already exists, there's no need to Put it, otherwise it gets handled inside the Do block, so still no need for a Put.

In the https://github.com/droyo/styx/pull/30 PR, @seh-msft says:

In the case of a new file being created in the tree, a Twalk, then a Tcreate, would occur.

If there's a new file being created, that means the file doesn't exist yet, which means the Twalk should fail. In the event of an unsuccessful Twalk, no new Qid should be created. I've added a new test that verifies this behaviour is true.

Tcreate should be the only origin of 'new' QIDs to the core file system.

Considering the above, this is still true: Twalk fails, no Qid is created, then Tcreate occurs, and the Qid and file get created.

In conclusion, the current behaviour is correct, so this PR reverts back to that -- there was no need for a fix. I am not sure what issues the original submitter was facing, but I am guessing that they were not coming from styx.

Resolves https://github.com/droyo/styx/issues/31